### PR TITLE
Support for HTML and Markdown in Send_messages

### DIFF
--- a/spark/messages.py
+++ b/spark/messages.py
@@ -9,6 +9,8 @@ class Message(object):
             self.attributes = dict()
             self.attributes['text'] = None
             self.attributes['roomId'] = None
+	    self.attributes['markdown'] = None
+	    self.attributes['html'] = None
 
     @property
     def text(self):
@@ -25,6 +27,22 @@ class Message(object):
     @roomId.setter
     def roomId(self, val):
         self.attributes['roomId'] = val
+
+    @property
+    def markdown(self):
+	self.attributes['markdown'] = val
+
+    @markdown.setter
+    def roomId(self, val):
+        self.attributes['markdown'] = val
+
+    @property
+    def html(self):
+        self.attributes['html'] = val
+
+    @html.setter
+    def roomId(self, val):
+        self.attributes['html'] = val
 
     def json(self):
         return json.dumps(self.attributes)

--- a/spark/messages.py
+++ b/spark/messages.py
@@ -33,7 +33,7 @@ class Message(object):
 	self.attributes['markdown'] = val
 
     @markdown.setter
-    def roomId(self, val):
+    def html(self, val):
         self.attributes['markdown'] = val
 
     @property
@@ -41,7 +41,7 @@ class Message(object):
         self.attributes['html'] = val
 
     @html.setter
-    def roomId(self, val):
+    def html(self, val):
         self.attributes['html'] = val
 
     def json(self):

--- a/spark/rooms.py
+++ b/spark/rooms.py
@@ -75,7 +75,7 @@ class Room(object):
         elif frmt == 'html':
             message = spark.messages.Message()
             message.html = msg
-	    message.text = remove_tags(msg)
+	    message.text = msg
 	elif frmt == 'markdown':
 	    message = spark.messages.Message()
 	    message.markdown = msg
@@ -96,10 +96,6 @@ class Room(object):
             obj = spark.messages.Message(attributes=msg)
             ret.append(obj)
         return ret
-
-    #function to remove html tags
-    def remove_tags(text):
-    ''.join(xml.etree.ElementTree.fromstring(text).itertext())
 
     @classmethod
     def get(cls, session, name=None):

--- a/spark/rooms.py
+++ b/spark/rooms.py
@@ -69,10 +69,18 @@ class Room(object):
     def json(self):
         return json.dumps(self.attributes)
 
-    def send_message(self, session, msg):
+    def send_message(self, session, msg, frmt=None):
         if isinstance(msg, spark.messages.Message):
             message = msg
-        else:
+        elif frmt == 'html':
+            message = spark.messages.Message()
+            message.html = msg
+	    message.text = remove_tags(msg)
+	elif frmt == 'markdown':
+	    message = spark.messages.Message()
+	    message.markdown = msg
+	    message.text = msg;
+	else:
             message = spark.messages.Message()
             message.text = msg
         message.roomId = self.id
@@ -88,6 +96,10 @@ class Room(object):
             obj = spark.messages.Message(attributes=msg)
             ret.append(obj)
         return ret
+
+    #function to remove html tags
+    def remove_tags(text):
+    ''.join(xml.etree.ElementTree.fromstring(text).itertext())
 
     @classmethod
     def get(cls, session, name=None):


### PR DESCRIPTION
send_message now supports a third argument call frmt.

frmt is defaulted to none which is standard text
html - allows for formatting of html
markdown - allows for formatting of markdown

see spark API here:  https://developer.ciscospark.com/endpoint-messages-post.html